### PR TITLE
Fix localhost proxy headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ import { read_db } from "./backend/databaseDriverPostgres.js";
 const app = express();
 app.use(bodyParser.json());
 app.use(cors());
+app.set('trust proxy', 'loopback')
 
 const server = http.createServer(app);
 const io = io_realtime(server);


### PR DESCRIPTION
Under some circumstances, API calls on localhost get redirected. When this happens, the original subdomain information in the request is lost. This PR trust the loopback proxy server so that the subdomain information is passed over.

Example of "bad" headers:

```js
{
  'x-forwarded-host': 'daniele.localhost:3000',
  'x-forwarded-proto': 'http',
  'x-forwarded-port': '3000',
  'x-forwarded-for': '127.0.0.1',
  'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8',
  'accept-encoding': 'gzip, deflate, br',
  referer: 'http://daniele.localhost:3000/in-call',
  'sec-fetch-dest': 'empty',
  'sec-fetch-mode': 'cors',
  'sec-fetch-site': 'same-origin',
  origin: 'http://localhost:5100/',
  'sec-ch-ua-platform': '"macOS"',
  'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.109 Safari/537.36',
  'sec-ch-ua-mobile': '?0',
  'content-type': 'application/json;charset=UTF-8',
  accept: 'application/json, text/plain, */*',
  'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="98", "Google Chrome";v="98"',
  'content-length': '131',
  connection: 'close',
  host: 'localhost:5100'
}
```